### PR TITLE
Feature/per process metrics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ You'll need:
 Then:
 
 ```bash
-git clone https://github.com/manustays/menubar-cli-launcher.git
-cd menubar-cli-launcher
+git clone https://github.com/manustays/quay.git
+cd quay
 npm install
 npm run tauri dev      # launches the app in development mode
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Menubar Service Manager
+# Contributing to Quay
 
 Thanks for your interest in improving this project. This guide covers how to get set up, the conventions we follow, and how to get a change merged.
 
@@ -92,7 +92,7 @@ Open an issue with:
 - macOS version and chip (Apple Silicon / Intel)
 - What you did, what you expected, what happened
 - Relevant log output — per-item logs live at
-  `~/Library/Application Support/com.abhi.menubar-service-manager/logs/<id>.log`
+  `~/Library/Application Support/com.abhi.quay/logs/<id>.log`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# Menubar Service Manager
+# Quay
 
+> **Quay** _(pronounced "key")_ — **Where your ports come in.**
+>
 > A native macOS menubar app to start, stop, and monitor your local dev services — Node/Python servers, Homebrew services, and long-running terminal agents — from one place.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -12,24 +14,24 @@
 
 If you build a lot of local services, you know the dance: remember which folder, `cd` into it, run the start command, switch to the browser, and repeat for every project. Keeping several running at once means juggling terminal tabs and trying to remember what's up and on which port.
 
-**Menubar Service Manager** puts all of that one click away. Register an app folder once; then start it, see its live status, open its web UI, or drop into a terminal in its folder — straight from the menubar. It also manages Homebrew services (MySQL, MongoDB, Redis…) and long-running terminal agents.
+**Quay** puts all of that one click away. Register an app folder once; then start it, see its live status, open its web UI, or drop into a terminal in its folder — straight from the menubar. It also manages Homebrew services (MySQL, MongoDB, Redis…) and long-running terminal agents.
 
 ## What it looks like
 
 Click the menubar icon and a popover opens:
 
 ```
-┌─────────────────────────────────────┐
-│ 🔍 search…              [ ■ Stop all]│
-├─────────────────────────────────────┤
-│ ★ FAVORITES                         │
-│  ● myapp     :5173  [■][↗][>_]      │
-│  ● claude    term   [■]    [>_]      │
-├─────────────────────────────────────┤
-│  ▸ More (4)                          │
-├─────────────────────────────────────┤
+┌────────────────────────────────────——─┐
+│ 🔍 search…              [ ■ Stop all] │
+├──────────────────────────────────——───┤
+│ ★ FAVORITES                           │
+│  ● myapp     :5173  [■][↗][>_]        │
+│  ● claude    term   [■]    [>_]       │
+├────────────────────────────────────——─┤
+│  ▸ More (4)                           │
+├────────────────────────────────────——─┤
 │  [+ Add]                  [⚙ Settings]│
-└─────────────────────────────────────┘
+└───────────────────────────────────——──┘
 ```
 
 Status at a glance: ● running (green) · ◐ starting (yellow) · ○ stopped (grey) · ✖ error (red).

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Status at a glance: ● running (green) · ◐ starting (yellow) · ○ stopped 
 There are no pre-built signed releases yet, so the supported path today is **build from source** (or build your own `.dmg`).
 
 ```bash
-git clone https://github.com/manustays/menubar-cli-launcher.git
-cd menubar-cli-launcher
+git clone https://github.com/manustays/quay.git
+cd quay
 npm install
 npm run tauri build      # produces a .app and .dmg under src-tauri/target/release/bundle/
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-A contributor-facing overview of how Menubar Service Manager is built. For the original decisions and rationale, see the [design spec](specs/2026-06-26-menubar-service-manager-design.md).
+A contributor-facing overview of how Quay is built. For the original decisions and rationale, see the [design spec](specs/2026-06-26-menubar-service-manager-design.md).
 
 ## Big picture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ Each module has a single responsibility:
 | `brew` | Wrap `brew services start/stop/list` and parse the list output into per-formula statuses. |
 | `supervisor` | Spawn a background item via `zsh -lc "<cmd>"` in its **own process group** (`setsid`), redirect stdout/stderr to `logs/<id>.log`, and stop it by signalling the group (SIGTERM, escalating to SIGKILL). Also **adopts** orphaned services across app restarts: `adopt` (handle-less, PID-only), `pids_listening`/`parse_lsof_pids` (find listeners via `lsof`), and `stop_port` (free a port by killing its listeners). See [process reattachment](process-reattach.md). |
 | `health` | The pure `decide_status` function (PID liveness × port/HTTP reachability → status), the TCP/HTTP probes, and the background poll loop that emits `status_changed`. |
+| `metrics` | Per-process CPU%/memory sampling via `sysinfo`. A visibility-gated loop (`AppState.visible`) samples only while the popover is open, aggregates each item's whole process tree (pure `aggregate_tree`), and emits `metrics_changed`. See [metrics](metrics.md). |
 | `terminal` | Build the shell line and drive Terminal.app / iTerm2 via `osascript` (open a folder, or run a `terminal`-mode item). |
 | `state` | `AppState` — shared mutable state behind `Mutex`es: the loaded config, the map of running children, the status map, and the error map, plus a `suppress_hide` flag and the data dir. |
 | `commands` | All `#[tauri::command]` handlers, plus `init_state`. |
@@ -73,6 +74,12 @@ A single background thread runs every `pollIntervalSec`:
 - It calls `set_status`, which emits `status_changed` **only when the status actually changed** (so the UI isn't spammed).
 
 The poll loop deliberately releases the `running` lock before doing the (blocking) port/HTTP probe, so a slow probe never stalls command handlers.
+
+### Metrics sampling
+
+A second background thread (`metrics::spawn_metrics_loop`) samples per-process CPU% and memory, but **only while the popover is visible** — gated on `AppState.visible`, which `lib.rs` flips on successful window show/hide (and on genuine hide-on-blur, but not while a native dialog suppresses hiding). While hidden it idle-ticks every 500 ms and does no sampling work.
+
+Each pass resolves root PIDs per running item (the tracked child PID, plus any port listeners via `pids_listening` — covering terminal/brew items and reparented servers), takes two `sysinfo` refreshes 200 ms apart so CPU% is a valid delta, then sums each item's whole process tree with the pure `aggregate_tree` helper. The result is pushed as a full snapshot via `metrics_changed`; the frontend replaces its map wholesale so stopped items drop out. See [metrics](metrics.md).
 
 ### Shutdown
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,13 +5,13 @@ All state is stored in a single JSON file. You normally edit it through the app'
 ## Location
 
 ```
-~/Library/Application Support/com.abhi.menubar-service-manager/config.json
+~/Library/Application Support/com.abhi.quay/config.json
 ```
 
 Per-item logs live alongside it:
 
 ```
-~/Library/Application Support/com.abhi.menubar-service-manager/logs/<id>.log
+~/Library/Application Support/com.abhi.quay/logs/<id>.log
 ```
 
 The file is written atomically (temp file + rename) on every change. If it ever becomes unreadable or corrupt, the app backs it up to `config.bad.json` and starts fresh with defaults — so a bad edit won't crash the app.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ The file is written atomically (temp file + rename) on every change. If it ever 
 |-------|------|---------|-------------|
 | `terminalApp` | `"Terminal"` \| `"iTerm"` | `"Terminal"` | Which terminal emulator the "open terminal" action and `terminal`-mode items use. |
 | `pollIntervalSec` | number | `3` | How often (seconds) the background loop re-checks each item's status. Minimum 1. |
+| `metricsIntervalSec` | number | `10` | How often (seconds) per-process CPU%/memory are sampled **while the popover is open**. No sampling happens while it's closed. Minimum 1. See [metrics](metrics.md). |
 | `browser` | string | `"default"` | Reserved; the browser action currently always uses the system default browser. |
 | `launchAtLogin` | boolean | `false` | Whether the app is registered as a macOS login item. Toggle via Settings (it also calls the OS API). |
 
@@ -96,6 +97,7 @@ Runtime state (PIDs, current status, log handles) is **not** persisted — it li
   "settings": {
     "terminalApp": "iTerm",
     "pollIntervalSec": 2,
+    "metricsIntervalSec": 10,
     "browser": "default",
     "launchAtLogin": true
   },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,8 +22,8 @@ If it's missing, restart your shell or `source "$HOME/.cargo/env"`. See [Trouble
 ## Option A — Build and run from source (quickest to try)
 
 ```bash
-git clone https://github.com/manustays/menubar-cli-launcher.git
-cd menubar-cli-launcher
+git clone https://github.com/manustays/quay.git
+cd quay
 npm install
 npm run tauri dev
 ```
@@ -35,8 +35,8 @@ The first run compiles all Rust dependencies and may take a couple of minutes. W
 ## Option B — Build a release app and install it
 
 ```bash
-git clone https://github.com/manustays/menubar-cli-launcher.git
-cd menubar-cli-launcher
+git clone https://github.com/manustays/quay.git
+cd quay
 npm install
 npm run tauri build
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Menubar Service Manager is **macOS only**. There are no pre-built signed releases yet, so you install it by building from source (or by building your own `.dmg` and installing that).
+Quay is **macOS only**. There are no pre-built signed releases yet, so you install it by building from source (or by building your own `.dmg` and installing that).
 
 ## Prerequisites
 
@@ -43,15 +43,15 @@ npm run tauri build
 
 This produces:
 
-- The app bundle: `src-tauri/target/release/bundle/macos/Menubar Service Manager.app`
-- A disk image: `src-tauri/target/release/bundle/dmg/Menubar Service Manager_0.1.0_<arch>.dmg`
+- The app bundle: `src-tauri/target/release/bundle/macos/Quay.app`
+- A disk image: `src-tauri/target/release/bundle/dmg/Quay_0.1.0_<arch>.dmg`
 
 Install it by either:
 
-- Opening the `.dmg` and dragging **Menubar Service Manager** to `/Applications`, or
+- Opening the `.dmg` and dragging **Quay** to `/Applications`, or
 - Copying the `.app` straight to `/Applications`:
   ```bash
-  cp -R "src-tauri/target/release/bundle/macos/Menubar Service Manager.app" /Applications/
+  cp -R "src-tauri/target/release/bundle/macos/Quay.app" /Applications/
   ```
 
 ### "App can't be opened because it is from an unidentified developer"
@@ -59,7 +59,7 @@ Install it by either:
 A locally-built app is unsigned, so Gatekeeper will warn on first launch. To open it anyway:
 
 - **Right-click** the app in `/Applications` → **Open** → **Open** in the dialog, **or**
-- Run once: `xattr -dr com.apple.quarantine "/Applications/Menubar Service Manager.app"`
+- Run once: `xattr -dr com.apple.quarantine "/Applications/Quay.app"`
 
 To produce a properly **signed and notarized** build that opens without warnings (recommended if you distribute it to others), see [Packaging & distribution](packaging.md).
 
@@ -69,7 +69,7 @@ To produce a properly **signed and notarized** build that opens without warnings
 - Left-click the icon → popover. Right-click the icon → **Quit**.
 - On first run there are no items — click **+ Add** to register your first service. See the [Usage guide](usage.md).
 - Configuration and logs are written to
-  `~/Library/Application Support/com.abhi.menubar-service-manager/`.
+  `~/Library/Application Support/com.abhi.quay/`.
 
 ## Updating
 
@@ -86,7 +86,7 @@ Your `config.json` is stored outside the project directory, so it is preserved a
 ## Uninstalling
 
 1. Quit the app (tray → **Quit**).
-2. Delete the app: `rm -rf "/Applications/Menubar Service Manager.app"`.
+2. Delete the app: `rm -rf "/Applications/Quay.app"`.
 3. (Optional) Remove its data:
-   `rm -rf "~/Library/Application Support/com.abhi.menubar-service-manager"`.
+   `rm -rf "~/Library/Application Support/com.abhi.quay"`.
 4. (Optional) If you enabled **Launch at login**, disable it first in Settings, or remove the login item under **System Settings → General → Login Items**.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,59 @@
+# Per-process metrics (CPU% + memory)
+
+Each running service shows live **CPU%** and **memory** next to its port/descriptor in
+the popover. Metrics are sampled cheaply: only while the popover is open, on a
+configurable interval (default 10s).
+
+## Why visibility-gated
+
+The status poll (`health`) runs continuously in the background because status drives the
+UI dots and reattachment. Metrics are different — they're only worth anything while the
+user is looking at the list. Sampling them continuously would burn CPU (and run `lsof`)
+every few seconds forever, for data nobody sees.
+
+So the metrics loop is gated on `AppState.visible`:
+
+- `lib.rs::toggle_popover` sets `visible = true` after a successful `show()`, `false` after
+  a successful `hide()`.
+- The hide-on-blur handler sets `visible = false` **only when the window is actually
+  hidden** — during a native dialog (`suppress_hide`) the popover stays open, so sampling
+  must continue.
+- The flag mirrors the *actual* outcome of each window op, never just the intended branch.
+
+While hidden the loop idle-ticks every 500 ms and does zero sampling work; that bounds the
+latency to the first sample after opening to ≤0.5s. It also re-checks `visible` after a
+collection (which takes ~200 ms + `lsof`) and skips the emit if the popover closed meanwhile.
+
+## How a sample is taken
+
+For each item whose status is `running`/`starting`, `metrics::collect`:
+
+1. **Resolves root PIDs.** The tracked child PID (background items), **plus** any port
+   listeners via `supervisor::pids_listening(port)`. The union covers terminal/brew items
+   (no tracked PID) and background servers whose launcher shell was reparented away. Each
+   port is resolved at most once per pass (cached).
+2. **Samples with `sysinfo`.** Two `refresh_processes` calls 200 ms apart
+   (`MINIMUM_CPU_UPDATE_INTERVAL`) so `cpu_usage()` has a valid delta to measure; memory is
+   read as resident bytes.
+3. **Aggregates the process tree.** `aggregate_tree` (pure, unit-tested) walks each root's
+   descendants via parent links, deduping shared PIDs, summing CPU% and memory. This is why
+   an `npm → node → worker` service reports the real total, not the near-zero wrapper.
+
+The result — one `ItemMetrics { id, cpuPercent, memoryBytes }` per item with live PIDs — is
+emitted as a **full snapshot** on the `metrics_changed` event. The frontend rebuilds its
+metrics map wholesale per event, so a service that stopped between ticks drops out and no
+stale numbers linger.
+
+## Notes & limits
+
+- **`cpuPercent` is summed across cores** — it can exceed 100% for a busy multi-threaded
+  tree (same convention as Activity Monitor's per-process "%CPU").
+- **Portless brew services show nothing** — there's no tracked PID and no port to resolve
+  them by. (A brew service with a configured port does get metrics.)
+- **Cost is bounded to "while open."** Closed popover = no `sysinfo`, no `lsof`.
+
+## Configuration
+
+`metricsIntervalSec` (default `10`, min `1`) controls the sampling cadence — set via
+**Settings → Metrics interval (sec)**. Read fresh each tick, so changes take effect on the
+next cycle. See [configuration](configuration.md).

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -15,8 +15,8 @@ Outputs:
 
 | Artifact | Path |
 |----------|------|
-| App bundle | `src-tauri/target/release/bundle/macos/Menubar Service Manager.app` |
-| Disk image | `src-tauri/target/release/bundle/dmg/Menubar Service Manager_0.1.0_<arch>.dmg` |
+| App bundle | `src-tauri/target/release/bundle/macos/Quay.app` |
+| Disk image | `src-tauri/target/release/bundle/dmg/Quay_0.1.0_<arch>.dmg` |
 
 `<arch>` is `aarch64` on Apple Silicon or `x64` on Intel. An unsigned build runs locally but triggers a Gatekeeper warning on other machines (see [Installation](installation.md#app-cant-be-opened-because-it-is-from-an-unidentified-developer)).
 
@@ -95,10 +95,10 @@ Tauri will sign, notarize, and staple the ticket to the bundle. The resulting `.
 
 ```bash
 # signature
-codesign --verify --deep --strict --verbose=2 "src-tauri/target/release/bundle/macos/Menubar Service Manager.app"
+codesign --verify --deep --strict --verbose=2 "src-tauri/target/release/bundle/macos/Quay.app"
 
 # notarization / Gatekeeper assessment
-spctl -a -vvv -t install "src-tauri/target/release/bundle/macos/Menubar Service Manager.app"
+spctl -a -vvv -t install "src-tauri/target/release/bundle/macos/Quay.app"
 ```
 
 A notarized app reports `source=Notarized Developer ID` and `accepted`.
@@ -130,7 +130,7 @@ You can automate signed, notarized builds in GitHub Actions with [`tauri-apps/ta
 `npm run tauri build` compiles the app and bundles the `.app`, then fails when building the `.dmg`:
 
 ```
-Bundling Menubar Service Manager_0.1.0_aarch64.dmg ...
+Bundling Quay_0.1.0_aarch64.dmg ...
      Running bundle_dmg.sh
 failed to bundle project: error running bundle_dmg.sh
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,7 +3,7 @@
 Common issues and how to fix them. Per-item logs are your best friend — find them at:
 
 ```
-~/Library/Application Support/com.abhi.menubar-service-manager/logs/<id>.log
+~/Library/Application Support/com.abhi.quay/logs/<id>.log
 ```
 
 ## `cargo` not found
@@ -33,7 +33,7 @@ A locally-built app isn't signed, so Gatekeeper blocks the first launch. Either:
 - **Right-click** the app → **Open** → **Open**, or
 - Clear the quarantine flag:
   ```bash
-  xattr -dr com.apple.quarantine "/Applications/Menubar Service Manager.app"
+  xattr -dr com.apple.quarantine "/Applications/Quay.app"
   ```
 
 For a build that opens with no warning, sign and notarize it — see [Packaging](packaging.md).
@@ -98,7 +98,7 @@ Toggle it in **Settings**. You can verify/remove it under **System Settings → 
 Quit the app, then remove its data directory and relaunch with a clean slate:
 
 ```bash
-rm -rf "~/Library/Application Support/com.abhi.menubar-service-manager"
+rm -rf "~/Library/Application Support/com.abhi.quay"
 ```
 
 If only the config is bad, the app already auto-recovers: a corrupt `config.json` is moved to `config.bad.json` on launch and replaced with defaults.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,4 +111,4 @@ Fix: re-run and approve the “control Finder / System Events” prompt, or pre-
 
 ## Still stuck?
 
-Open an issue at <https://github.com/manustays/menubar-cli-launcher/issues> with your macOS version + chip, what you did, and the relevant log output.
+Open an issue at <https://github.com/manustays/quay/issues> with your macOS version + chip, what you did, and the relevant log output.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-This guide walks through the day-to-day use of Menubar Service Manager.
+This guide walks through the day-to-day use of Quay.
 
 ## The popover
 
@@ -104,7 +104,7 @@ The header **Stop all** button (with confirmation) stops every running backgroun
 
 ## Where things live
 
-- **Config:** `~/Library/Application Support/com.abhi.menubar-service-manager/config.json`
-- **Logs:** `~/Library/Application Support/com.abhi.menubar-service-manager/logs/<id>.log` (one per item)
+- **Config:** `~/Library/Application Support/com.abhi.quay/config.json`
+- **Logs:** `~/Library/Application Support/com.abhi.quay/logs/<id>.log` (one per item)
 
 See [Configuration](configuration.md) for the full file format.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,8 @@ Each row shows a colored dot:
 
 Status is refreshed automatically by a background poll (every few seconds, configurable). You never need to manually refresh.
 
+Running rows also show live **CPU% · memory** next to the port — sampled only while the popover is open, every 10s by default. See [metrics](metrics.md).
+
 ### Row actions
 
 | Button | Action | Shown when |
@@ -97,6 +99,7 @@ The header **Stop all** button (with confirmation) stops every running backgroun
 
 - **Terminal app** — `Terminal` (default) or `iTerm`. Used for the "open terminal" action and `terminal`-mode items.
 - **Poll interval (sec)** — how often status is checked (default 3).
+- **Metrics interval (sec)** — how often per-process CPU%/memory are sampled while the popover is open (default 10). See [metrics](metrics.md).
 - **Launch at login** — register/unregister the app as a macOS login item.
 
 ## Where things live

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="/src/index.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Menubar Service Manager</title>
+    <title>Quay</title>
     <script type="module" src="/src/main.tsx" defer></script>
   </head>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "menubar-service-manager",
+  "name": "quay",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "menubar-service-manager",
+      "name": "quay",
       "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "menubar-service-manager",
+  "name": "quay",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1747,24 +1747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "menubar-service-manager"
-version = "0.1.0"
-dependencies = [
- "dirs 5.0.1",
- "libc",
- "serde",
- "serde_json",
- "sysinfo",
- "tauri",
- "tauri-build",
- "tauri-plugin-autostart",
- "tauri-plugin-dialog",
- "tauri-plugin-positioner",
- "ureq",
- "uuid",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2338,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quay"
+version = "0.1.0"
+dependencies = [
+ "dirs 5.0.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
+ "tauri-plugin-positioner",
+ "ureq",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1754,6 +1754,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -1840,6 +1841,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-conv"
@@ -2007,6 +2017,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2035,17 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3018,6 +3049,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,7 +3110,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3135,7 +3181,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3309,7 +3355,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3334,7 +3380,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4103,7 +4149,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -4127,7 +4173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4183,11 +4229,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -4197,6 +4255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4233,7 +4300,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -4278,6 +4356,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4440,6 +4528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4724,7 +4821,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "menubar-service-manager"
+name = "quay"
 version = "0.1.0"
 description = "A native macOS menubar app to start, stop, and monitor your local dev services, Homebrew services, and terminal agents."
 authors = ["Kumar Abhishek <manustays@gmail.com>"]
 license = "MIT"
-repository = "https://github.com/manustays/menubar-cli-launcher"
-homepage = "https://github.com/manustays/menubar-cli-launcher"
+repository = "https://github.com/manustays/quay"
+homepage = "https://github.com/manustays/quay"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -14,7 +14,7 @@ edition = "2021"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "menubar_service_manager_lib"
+name = "quay_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,4 +31,5 @@ libc = "0.2"
 ureq = "3.3.0"
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-autostart = "2.5.1"
+sysinfo = "0.39"
 

--- a/src-tauri/src/brew.rs
+++ b/src-tauri/src/brew.rs
@@ -1,6 +1,77 @@
 use crate::model::{AppError, Status};
 use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
+
+/// Candidate `brew` binary paths in priority order.
+///
+/// `$HOMEBREW_PREFIX/bin/brew` first (honours custom installs), then the two
+/// standard locations: Apple Silicon, then Intel. An empty prefix is ignored.
+fn brew_candidates(homebrew_prefix: Option<&str>) -> Vec<PathBuf> {
+	let mut v = Vec::new();
+	if let Some(p) = homebrew_prefix {
+		if !p.is_empty() {
+			v.push(PathBuf::from(p).join("bin/brew"));
+		}
+	}
+	v.push(PathBuf::from("/opt/homebrew/bin/brew"));
+	v.push(PathBuf::from("/usr/local/bin/brew"));
+	v
+}
+
+/// True if `path` is a regular file with at least one executable bit set.
+fn is_executable(path: &Path) -> bool {
+	std::fs::metadata(path)
+		.map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+		.unwrap_or(false)
+}
+
+/// Ask the user's login shell where `brew` lives (covers nonstandard prefixes).
+///
+/// Runs `zsh -lc 'command -v brew'`, which sources the login profile so it sees
+/// the same PATH a terminal would. Returns `None` if the shell or brew is absent.
+fn login_shell_brew() -> Option<PathBuf> {
+	let out = Command::new("/bin/zsh").args(["-lc", "command -v brew"]).output().ok()?;
+	if !out.status.success() {
+		return None;
+	}
+	let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+	let pb = PathBuf::from(path);
+	is_executable(&pb).then_some(pb)
+}
+
+/// Resolve the `brew` binary: first executable candidate, then a login-shell
+/// lookup, else the bare name `"brew"` (relies on PATH, as in dev mode).
+fn resolve_brew() -> PathBuf {
+	for c in brew_candidates(std::env::var("HOMEBREW_PREFIX").ok().as_deref()) {
+		if is_executable(&c) {
+			return c;
+		}
+	}
+	login_shell_brew().unwrap_or_else(|| PathBuf::from("brew"))
+}
+
+/// Absolute path to `brew`, resolved once and cached for the process lifetime.
+///
+/// A bundled `.app` launched from Finder/Dock gets a minimal PATH without the
+/// Homebrew dir, so a bare `Command::new("brew")` fails there; resolving the
+/// absolute path fixes brew listing and status detection in the bundled app.
+fn brew_bin() -> &'static Path {
+	static BIN: OnceLock<PathBuf> = OnceLock::new();
+	BIN.get_or_init(resolve_brew)
+}
+
+/// Raw stdout of `brew services list`, or `None` if `brew` couldn't be spawned.
+///
+/// Exit status is intentionally ignored (matching prior behaviour): a nonzero
+/// exit still returns whatever stdout was produced, which `parse_brew_list`
+/// tolerates.
+pub fn services_list_raw() -> Option<String> {
+	let out = Command::new(brew_bin()).args(["services", "list"]).output().ok()?;
+	Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
 
 /// Parse `brew services list` output into formula → Status.
 ///
@@ -23,10 +94,9 @@ pub fn parse_brew_list(output: &str) -> HashMap<String, Status> {
 
 /// Current status of a brew formula (Stopped if brew missing or formula absent).
 pub fn brew_status(formula: &str) -> Status {
-	let Ok(out) = Command::new("brew").args(["services", "list"]).output() else {
+	let Some(text) = services_list_raw() else {
 		return Status::Stopped;
 	};
-	let text = String::from_utf8_lossy(&out.stdout);
 	parse_brew_list(&text)
 		.get(formula)
 		.copied()
@@ -45,10 +115,11 @@ pub fn brew_stop(formula: &str) -> Result<(), AppError> {
 
 /// Run `brew services <action> <formula>`, surfacing stderr on failure.
 fn run_brew(action: &str, formula: &str) -> Result<(), AppError> {
-	let out = Command::new("brew")
+	let brew = brew_bin();
+	let out = Command::new(brew)
 		.args(["services", action, formula])
 		.output()
-		.map_err(|e| AppError::Message(format!("brew not found: {e}")))?;
+		.map_err(|e| AppError::Message(format!("brew ({}) failed to run: {e}", brew.display())))?;
 	if out.status.success() {
 		Ok(())
 	} else {
@@ -62,6 +133,36 @@ fn run_brew(action: &str, formula: &str) -> Result<(), AppError> {
 mod tests {
 	use super::*;
 	use crate::model::Status;
+
+	#[test]
+	fn candidate_order_prefers_homebrew_prefix() {
+		let c = brew_candidates(Some("/custom/brew"));
+		assert_eq!(c, vec![
+			PathBuf::from("/custom/brew/bin/brew"),
+			PathBuf::from("/opt/homebrew/bin/brew"),
+			PathBuf::from("/usr/local/bin/brew"),
+		]);
+	}
+
+	#[test]
+	fn candidate_order_without_prefix_skips_empty() {
+		let expected = vec![
+			PathBuf::from("/opt/homebrew/bin/brew"),
+			PathBuf::from("/usr/local/bin/brew"),
+		];
+		assert_eq!(brew_candidates(None), expected);
+		// An empty prefix is ignored, not turned into "/bin/brew".
+		assert_eq!(brew_candidates(Some("")), expected);
+	}
+
+	#[test]
+	fn is_executable_distinguishes_files_and_dirs() {
+		// A directory is never "executable" in our sense (not a regular file).
+		assert!(!is_executable(Path::new("/opt")));
+		// /bin/sh exists and is executable on macOS.
+		assert!(is_executable(Path::new("/bin/sh")));
+		assert!(!is_executable(Path::new("/no/such/brew")));
+	}
 
 	#[test]
 	fn parses_brew_services_list() {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -124,6 +124,7 @@ pub fn init_state(dir: std::path::PathBuf) -> AppState {
 		statuses: std::sync::Mutex::new(std::collections::HashMap::new()),
 		errors: std::sync::Mutex::new(std::collections::HashMap::new()),
 		suppress_hide: std::sync::atomic::AtomicBool::new(false),
+		visible: std::sync::atomic::AtomicBool::new(false),
 	}
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -320,9 +320,8 @@ pub fn tail_log(app: AppHandle, id: String, lines: usize) -> Result<String, AppE
 /// returns only the formula name keys. Returns an empty vec if brew is unavailable.
 #[tauri::command]
 pub fn list_brew_formulae() -> Vec<String> {
-	let Ok(out) = std::process::Command::new("brew").args(["services", "list"]).output() else {
+	let Some(text) = brew::services_list_raw() else {
 		return vec![];
 	};
-	let text = String::from_utf8_lossy(&out.stdout);
 	brew::parse_brew_list(&text).into_keys().collect()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ pub mod brew;
 pub mod commands;
 pub mod detect;
 pub mod health;
+pub mod metrics;
 pub mod model;
 pub mod state;
 pub mod store;
@@ -17,16 +18,22 @@ use tauri::{
 
 /// Toggle the popover window: show+focus if hidden, hide if visible.
 fn toggle_popover(app: &tauri::AppHandle) {
+	use std::sync::atomic::Ordering;
 	if let Some(win) = app.get_webview_window("main") {
 		if win.is_visible().unwrap_or(false) {
-			let _ = win.hide();
+			// Mirror `visible` to the actual outcome of the window op.
+			if win.hide().is_ok() {
+				app.state::<state::AppState>().visible.store(false, Ordering::Relaxed);
+			}
 		} else {
 			let _ = tauri_plugin_positioner::WindowExt::move_window(
 				&win,
 				tauri_plugin_positioner::Position::TrayCenter,
 			);
-			let _ = win.show();
-			let _ = win.set_focus();
+			if win.show().is_ok() {
+				app.state::<state::AppState>().visible.store(true, Ordering::Relaxed);
+				let _ = win.set_focus();
+			}
 		}
 	}
 }
@@ -112,6 +119,9 @@ pub fn run() {
 			// Start the background status-poll loop.
 			health::spawn_poll_loop(app.handle().clone());
 
+			// Start the metrics loop (only samples while the popover is visible).
+			metrics::spawn_metrics_loop(app.handle().clone());
+
 			// Auto-start any items flagged with auto_start = true.
 			{
 				let app_handle = app.handle().clone();
@@ -178,7 +188,16 @@ pub fn run() {
 						.suppress_hide
 						.load(std::sync::atomic::Ordering::Relaxed);
 					if !suppress {
-						let _ = window.hide();
+						// Only clear `visible` when the popover is genuinely hidden —
+						// during a native dialog (suppress_hide) it stays open, so the
+						// metrics loop must keep sampling.
+						if window.hide().is_ok() {
+							window
+								.app_handle()
+								.state::<state::AppState>()
+								.visible
+								.store(false, std::sync::atomic::Ordering::Relaxed);
+						}
 					}
 				}
 			}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    menubar_service_manager_lib::run()
+    quay_lib::run()
 }

--- a/src-tauri/src/metrics.rs
+++ b/src-tauri/src/metrics.rs
@@ -1,0 +1,190 @@
+//! Per-process CPU% and memory sampling, gated on popover visibility.
+//!
+//! Unlike the always-on health poll ([`crate::health`]), this loop only does work
+//! while the popover is open (`AppState.visible`). Each pass takes a self-contained
+//! pair of `sysinfo` refreshes 200 ms apart so CPU% is a valid instantaneous delta,
+//! then aggregates each service's whole process tree (root PIDs + descendants) so
+//! wrapper processes (e.g. `npm` → `node`) report the real consumption.
+
+use crate::model::Status;
+use crate::state::AppState;
+use crate::supervisor;
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use sysinfo::{MINIMUM_CPU_UPDATE_INTERVAL, ProcessesToUpdate, System};
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Resource usage for one item, pushed to the frontend via `metrics_changed`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ItemMetrics {
+	pub id: String,
+	/// Summed CPU usage across the process tree, in percent (can exceed 100 on
+	/// multi-core machines — it is the sum of per-core percentages).
+	#[serde(rename = "cpuPercent")]
+	pub cpu_percent: f32,
+	/// Summed resident memory across the process tree, in bytes.
+	#[serde(rename = "memoryBytes")]
+	pub memory_bytes: u64,
+}
+
+/// Sum cpu% + memory over the union of subtrees rooted at `roots`, deduping
+/// shared PIDs. Pure — `children` maps parent PID → child PIDs, `samples` maps
+/// PID → (cpu%, memory bytes). PIDs absent from `samples` contribute nothing.
+pub fn aggregate_tree(
+	roots: &[u32],
+	children: &HashMap<u32, Vec<u32>>,
+	samples: &HashMap<u32, (f32, u64)>,
+) -> (f32, u64) {
+	let mut seen: HashSet<u32> = HashSet::new();
+	let mut stack: Vec<u32> = roots.to_vec();
+	let (mut cpu, mut mem) = (0.0_f32, 0_u64);
+	while let Some(pid) = stack.pop() {
+		if !seen.insert(pid) {
+			continue;
+		}
+		if let Some(&(c, m)) = samples.get(&pid) {
+			cpu += c;
+			mem += m;
+		}
+		if let Some(kids) = children.get(&pid) {
+			stack.extend(kids.iter().copied());
+		}
+	}
+	(cpu, mem)
+}
+
+/// Sample metrics for every running/starting item. Returns one entry per item
+/// that resolves to at least one live PID; an empty vec when nothing is running
+/// (the frontend replaces its whole map per event, so this clears stale rows).
+pub fn collect(app: &AppHandle) -> Vec<ItemMetrics> {
+	let state = app.state::<AppState>();
+
+	// Snapshot everything we need under locks, then release before blocking I/O
+	// (lsof in `pids_listening`, the 200 ms CPU sample) happens lock-free.
+	let items = state.config.lock().unwrap().items.clone();
+	let statuses = state.statuses.lock().unwrap().clone();
+	let tracked: HashMap<String, u32> = state
+		.running
+		.lock()
+		.unwrap()
+		.iter()
+		.map(|(id, r)| (id.clone(), r.pid))
+		.collect();
+
+	// Resolve root PIDs per item. A port is resolved at most once per pass.
+	let mut port_cache: HashMap<u16, Vec<u32>> = HashMap::new();
+	let mut item_roots: Vec<(String, Vec<u32>)> = Vec::new();
+	for item in &items {
+		match statuses.get(&item.id) {
+			Some(Status::Running | Status::Starting) => {}
+			_ => continue,
+		}
+		let mut roots: Vec<u32> = Vec::new();
+		if let Some(&pid) = tracked.get(&item.id) {
+			roots.push(pid);
+		}
+		// Port-resolved listeners cover terminal/brew items and background
+		// servers whose tracked launcher PID has been reparented away.
+		if let Some(port) = item.port {
+			let pids = port_cache
+				.entry(port)
+				.or_insert_with(|| supervisor::pids_listening(port));
+			roots.extend(pids.iter().copied());
+		}
+		roots.sort_unstable();
+		roots.dedup();
+		if !roots.is_empty() {
+			item_roots.push((item.id.clone(), roots));
+		}
+	}
+	if item_roots.is_empty() {
+		return Vec::new();
+	}
+
+	// Two refreshes 200 ms apart give cpu_usage() a valid delta to measure.
+	let mut sys = System::new();
+	sys.refresh_processes(ProcessesToUpdate::All, true);
+	std::thread::sleep(MINIMUM_CPU_UPDATE_INTERVAL);
+	sys.refresh_processes(ProcessesToUpdate::All, true);
+
+	let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+	let mut samples: HashMap<u32, (f32, u64)> = HashMap::new();
+	for (pid, proc_) in sys.processes() {
+		let pid_u = pid.as_u32();
+		samples.insert(pid_u, (proc_.cpu_usage(), proc_.memory()));
+		if let Some(parent) = proc_.parent() {
+			children.entry(parent.as_u32()).or_default().push(pid_u);
+		}
+	}
+
+	item_roots
+		.into_iter()
+		.map(|(id, roots)| {
+			let (cpu_percent, memory_bytes) = aggregate_tree(&roots, &children, &samples);
+			ItemMetrics { id, cpu_percent, memory_bytes }
+		})
+		.collect()
+}
+
+/// Spawn the visibility-gated metrics loop. Idle-ticks every 500 ms while hidden
+/// (≤0.5 s latency to first sample on open) and does no sampling work; while
+/// visible it samples, re-checks visibility, then emits `metrics_changed`.
+pub fn spawn_metrics_loop(app: AppHandle) {
+	std::thread::spawn(move || loop {
+		let visible = app.state::<AppState>().visible.load(Ordering::Relaxed);
+		if !visible {
+			std::thread::sleep(Duration::from_millis(500));
+			continue;
+		}
+		let metrics = collect(&app);
+		// Re-check after the (~200 ms + lsof) collection: the popover may have
+		// closed meanwhile, in which case skip the emit.
+		if app.state::<AppState>().visible.load(Ordering::Relaxed) {
+			let _ = app.emit("metrics_changed", &metrics);
+		}
+		let interval = app
+			.state::<AppState>()
+			.config
+			.lock()
+			.unwrap()
+			.settings
+			.metrics_interval_sec
+			.max(1);
+		std::thread::sleep(Duration::from_secs(interval));
+	});
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn samples(pairs: &[(u32, f32, u64)]) -> HashMap<u32, (f32, u64)> {
+		pairs.iter().map(|&(p, c, m)| (p, (c, m))).collect()
+	}
+
+	#[test]
+	fn sums_root_plus_descendants() {
+		// 100 → 200 → 300 (npm → node → worker)
+		let children: HashMap<u32, Vec<u32>> =
+			HashMap::from([(100, vec![200]), (200, vec![300])]);
+		let s = samples(&[(100, 1.0, 10), (200, 5.0, 50), (300, 2.0, 20)]);
+		assert_eq!(aggregate_tree(&[100], &children, &s), (8.0, 80));
+	}
+
+	#[test]
+	fn dedupes_overlapping_roots() {
+		// tracked PID 100 and a port-resolved child 200 both passed as roots.
+		let children: HashMap<u32, Vec<u32>> = HashMap::from([(100, vec![200])]);
+		let s = samples(&[(100, 1.0, 10), (200, 5.0, 50)]);
+		assert_eq!(aggregate_tree(&[100, 200], &children, &s), (6.0, 60));
+	}
+
+	#[test]
+	fn missing_samples_contribute_nothing() {
+		let children: HashMap<u32, Vec<u32>> = HashMap::new();
+		let s = samples(&[]);
+		assert_eq!(aggregate_tree(&[999], &children, &s), (0.0, 0));
+	}
+}

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -40,15 +40,22 @@ pub struct ManagedItem {
 pub struct Settings {
 	#[serde(rename = "terminalApp")] pub terminal_app: String,
 	#[serde(rename = "pollIntervalSec")] pub poll_interval_sec: u64,
+	#[serde(rename = "metricsIntervalSec", default = "default_metrics_interval_sec")]
+	pub metrics_interval_sec: u64,
 	pub browser: String,
 	#[serde(rename = "launchAtLogin")] pub launch_at_login: bool,
 }
+
+/// Default metrics sampling interval (seconds). Used both by `Settings::default`
+/// and as the serde fallback for configs written before this field existed.
+fn default_metrics_interval_sec() -> u64 { 10 }
 
 impl Default for Settings {
 	fn default() -> Self {
 		Self {
 			terminal_app: "Terminal".into(),
 			poll_interval_sec: 3,
+			metrics_interval_sec: default_metrics_interval_sec(),
 			browser: "default".into(),
 			launch_at_login: false,
 		}
@@ -108,6 +115,7 @@ mod tests {
 		let s = Settings::default();
 		assert_eq!(s.terminal_app, "Terminal");
 		assert_eq!(s.poll_interval_sec, 3);
+		assert_eq!(s.metrics_interval_sec, 10);
 		assert_eq!(s.browser, "default");
 		assert!(!s.launch_at_login);
 	}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -15,4 +15,8 @@ pub struct AppState {
 	/// When `true`, the `Focused(false)` window-event handler skips hiding the
 	/// popover. Set while a native dialog (e.g. folder picker) is open.
 	pub suppress_hide: AtomicBool,
+	/// `true` while the popover is actually shown. Gates the metrics loop so it
+	/// does no sampling work while the popover is hidden. Set true on show,
+	/// false only when the window is genuinely hidden (see `lib.rs`).
+	pub visible: AtomicBool,
 }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 /// Ensure and return the app's data directory, creating `logs/` subdirectory as well.
 pub fn config_dir() -> Result<PathBuf, AppError> {
 	let base = dirs::data_dir().ok_or_else(|| AppError::Message("no data dir".into()))?;
-	let dir = base.join("com.abhi.menubar-service-manager");
+	let dir = base.join("com.abhi.quay");
 	std::fs::create_dir_all(dir.join("logs"))?;
 	Ok(dir)
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
-	"productName": "Menubar Service Manager",
+	"productName": "Quay",
 	"version": "0.1.0",
-	"identifier": "com.abhi.menubar-service-manager",
+	"identifier": "com.abhi.quay",
 	"build": {
 		"beforeDevCommand": "npm run dev",
 		"devUrl": "http://localhost:1420",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { UnlistenFn } from '@tauri-apps/api/event';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import { getItems, getStatuses, onStatusChanged } from './ipc';
-import type { ManagedItem, Status } from './model';
+import { getItems, getStatuses, onStatusChanged, onMetricsChanged } from './ipc';
+import type { ItemMetrics, ManagedItem, Status } from './model';
 import { Popup } from './components/Popup';
 import { ServiceForm } from './components/ServiceForm';
 import { SettingsDialog } from './components/SettingsDialog';
@@ -29,6 +29,7 @@ export function App(): React.JSX.Element {
 	const [items, setItems] = useState<ManagedItem[]>([]);
 	const [statuses, setStatuses] = useState<Map<string, Status>>(new Map());
 	const [lastErrors, setLastErrors] = useState<Map<string, string>>(new Map());
+	const [metrics, setMetrics] = useState<Map<string, ItemMetrics>>(new Map());
 
 	// Dialog state: `editing` is undefined when closed, null for "add new",
 	// or the item being edited; `settingsOpen` toggles the settings dialog.
@@ -47,7 +48,14 @@ export function App(): React.JSX.Element {
 		// onStatusChanged resolves to an unlisten fn asynchronously; guard against
 		// the effect being torn down before the subscription resolves.
 		let cancelled = false;
-		let unlisten: UnlistenFn | undefined;
+		const unlisteners: UnlistenFn[] = [];
+		// Register an unlisten fn, or call it immediately if we already unmounted
+		// (the listen() promise can resolve after teardown).
+		const track = (fn: UnlistenFn) => {
+			if (cancelled) fn();
+			else unlisteners.push(fn);
+		};
+
 		void onStatusChanged((s) => {
 			setStatuses((prev) => new Map(prev).set(s.id, s.status));
 			setLastErrors((prev) => {
@@ -56,10 +64,13 @@ export function App(): React.JSX.Element {
 				else if (s.status !== 'error') next.delete(s.id);
 				return next;
 			});
-		}).then((fn) => {
-			if (cancelled) fn();
-			else unlisten = fn;
-		});
+		}).then(track);
+
+		// Metrics arrive as a full snapshot per tick; rebuild the map wholesale so
+		// stopped/removed items drop out (no stale CPU/memory lingers).
+		void onMetricsChanged((list) => {
+			setMetrics(new Map(list.map((m) => [m.id, m])));
+		}).then(track);
 
 		// Seed current statuses once. `status_changed` only fires on change, so a
 		// status set by the backend's startup poll (before this listener attached)
@@ -83,7 +94,7 @@ export function App(): React.JSX.Element {
 
 		return () => {
 			cancelled = true;
-			unlisten?.();
+			for (const fn of unlisteners) fn();
 		};
 	}, [refresh]);
 
@@ -93,6 +104,7 @@ export function App(): React.JSX.Element {
 				items={items}
 				statuses={statuses}
 				lastErrors={lastErrors}
+				metrics={metrics}
 				onChange={refresh}
 				onAdd={() => setEditing(null)}
 				onEdit={(item) => setEditing(item)}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -8,7 +8,7 @@ import {
 	CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { matchesSearch, splitFavorites, type ManagedItem, type Status } from '../model';
+import { matchesSearch, splitFavorites, type ItemMetrics, type ManagedItem, type Status } from '../model';
 import { stopAll } from '../ipc';
 import { ServiceRow } from './ServiceRow';
 
@@ -16,6 +16,7 @@ interface PopupProps {
 	items: ManagedItem[];
 	statuses: Map<string, Status>;
 	lastErrors: Map<string, string>;
+	metrics: Map<string, ItemMetrics>;
 	onChange: () => void;
 	onAdd: () => void;
 	onEdit: (item: ManagedItem) => void;
@@ -27,6 +28,7 @@ export function Popup({
 	items,
 	statuses,
 	lastErrors,
+	metrics,
 	onChange,
 	onAdd,
 	onEdit,
@@ -51,6 +53,7 @@ export function Popup({
 			item={item}
 			status={statusOf(item)}
 			lastError={lastErrors.get(item.id)}
+			metrics={metrics.get(item.id)}
 			index={index}
 			onChange={onChange}
 			onEdit={onEdit}

--- a/src/components/ServiceRow.tsx
+++ b/src/components/ServiceRow.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/collapsible';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import type { ManagedItem, Status } from '../model';
+import { formatBytes, type ItemMetrics, type ManagedItem, type Status } from '../model';
 import {
 	deleteItem,
 	openBrowser,
@@ -31,6 +31,7 @@ interface ServiceRowProps {
 	item: ManagedItem;
 	status: Status;
 	lastError: string | undefined;
+	metrics: ItemMetrics | undefined;
 	index: number;
 	onChange: () => void;
 	onEdit: (item: ManagedItem) => void;
@@ -60,6 +61,7 @@ export function ServiceRow({
 	item,
 	status,
 	lastError,
+	metrics,
 	index,
 	onChange,
 	onEdit,
@@ -116,6 +118,11 @@ export function ServiceRow({
 								<span className="font-mono text-[11px]">:{item.port}</span>
 							)}
 							<span className="text-[11px]">{descriptor(item)}</span>
+							{running && metrics && (
+								<span className="font-mono text-[11px] tabular-nums">
+									{metrics.cpuPercent.toFixed(0)}% · {formatBytes(metrics.memoryBytes)}
+								</span>
+							)}
 						</span>
 					</span>
 				</CollapsibleTrigger>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -80,6 +80,16 @@ export function SettingsDialog({ open, onOpenChange, onSaved }: SettingsDialogPr
 							/>
 						</div>
 
+						<div className="grid gap-1.5">
+							<Label className="text-xs text-muted-foreground">Metrics interval (sec)</Label>
+							<Input
+								type="number"
+								min={1}
+								value={settings.metricsIntervalSec}
+								onChange={(e) => set({ metricsIntervalSec: Number(e.target.value) || 10 })}
+							/>
+						</div>
+
 						<label className="flex items-center justify-between gap-2 text-[13px]">
 							<span>Launch at login</span>
 							<Switch

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import type { ManagedItem, Settings, ItemStatus, DetectResult } from './model';
+import type { ManagedItem, Settings, ItemStatus, ItemMetrics, DetectResult } from './model';
 
 export const getItems = () => invoke<ManagedItem[]>('get_items');
 export const addItem = (item: ManagedItem) => invoke<ManagedItem>('add_item', { item });
@@ -33,6 +33,16 @@ export const listBrewFormulae = () => invoke<string[]>('list_brew_formulae');
  */
 export function onStatusChanged(cb: (s: ItemStatus) => void): Promise<UnlistenFn> {
 	return listen<ItemStatus>('status_changed', (e) => cb(e.payload));
+}
+
+/**
+ * Subscribe to backend metrics events. The callback receives the full set of
+ * {@link ItemMetrics} for every running item on each sampling tick (the backend
+ * only emits while the popover is open). Replace your map wholesale per event so
+ * stopped/removed items drop out. Returns an unlisten function.
+ */
+export function onMetricsChanged(cb: (m: ItemMetrics[]) => void): Promise<UnlistenFn> {
+	return listen<ItemMetrics[]>('metrics_changed', (e) => cb(e.payload));
 }
 
 /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -35,8 +35,20 @@ export interface ManagedItem {
 export interface Settings {
 	terminalApp: string;
 	pollIntervalSec: number;
+	metricsIntervalSec: number;
 	browser: string;
 	launchAtLogin: boolean;
+}
+
+/**
+ * Per-item resource usage — mirrors the Rust `ItemMetrics` struct.
+ * `cpuPercent` is summed across the process tree (may exceed 100 on multi-core);
+ * `memoryBytes` is summed resident memory in bytes.
+ */
+export interface ItemMetrics {
+	id: string;
+	cpuPercent: number;
+	memoryBytes: number;
 }
 
 /**
@@ -69,6 +81,18 @@ export function statusDot(status: Status): string {
 		error: '✖ error',
 	};
 	return map[status];
+}
+
+/**
+ * Format a byte count as a compact human string (e.g. 134217728 → "128 MB").
+ * Uses binary units; falls back to "0 B" for zero/negatives.
+ */
+export function formatBytes(bytes: number): string {
+	if (bytes <= 0) return '0 B';
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	const exp = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+	const value = bytes / 1024 ** exp;
+	return `${value < 10 && exp > 0 ? value.toFixed(1) : Math.round(value)} ${units[exp]}`;
 }
 
 /**


### PR DESCRIPTION
Sample CPU% and memory for each running service and show them inline in
the popover. Sampling is gated on popover visibility (AppState.visible)
and runs on a configurable interval (metricsIntervalSec, default 10s), so
no work happens while the popover is closed.

- New `metrics` module: visibility-gated loop, sysinfo double-refresh for
  a valid CPU delta, and a pure `aggregate_tree` that sums each item's
  whole process tree (root PIDs + descendants) so wrappers like npm->node
  report real usage.
- Resolve root PIDs from the tracked child PID plus port listeners, so
  terminal/brew items and reparented servers are covered.
- Emit a full `metrics_changed` snapshot; the frontend replaces its map
  wholesale so stopped items drop out with no stale numbers.
- Add the metricsIntervalSec setting (Rust + TS) and a Settings input.